### PR TITLE
Dependency updates Sprint 26

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
@@ -3,6 +3,10 @@ Note: To create a PR using this template add the query parameter `template=manua
 
 # Maintenance tasks (to be completed by the assignee)
 ## EDC
+### Skipped updates
+The following known issues need to be reviewed in case a compatible version is available. Add new known issues as they appear.
+- [ ] ktlint 0.45.2 (higher version is not compatible with jlleitschuh plugin)
+
 ### Gradle update
 - [ ] Execute `gradlew dependencyUpdates` to get a report on Dependencies with updates
 - [ ] Update `settings.gradle.kts` (for libraries), `build.gradle.kts` (for plugins) and `gradle.properties` (for jacoco and ktlint)
@@ -19,7 +23,7 @@ Update versions in the following dockerfiles
 
 ## Conclusion
 - [ ] After updating all components check if everything still works
-    - [ ] Document any conflicts and skipped update by placing comments on this PR
+- [ ] This template has been updated to reflect the latest state of tasks required and known issues with upgrades
 
 # Review (to be completed by the reviewer)
 - [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github.

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     if: success()
     needs:
-      - unit-tests
+      - testing-and-sonar
     steps:
       - name: Summary of this workflow's overall outcome
         run: exit 0

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  unit-tests:
+  testing-and-sonar:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,11 +65,11 @@ subprojects {
 plugins {
     id("org.springframework.boot") version "2.7.3" apply false
     id("io.gitlab.arturbosch.detekt") version "1.20.0"
-    id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     kotlin("jvm") version "1.7.10"
     kotlin("plugin.spring") version "1.7.10" apply false
     id("org.sonarqube") version "3.4.0.2513"
-    id("org.openapi.generator") version "6.0.1" apply false
+    id("org.openapi.generator") version "6.1.0" apply false
     id("org.springdoc.openapi-gradle-plugin") version "1.4.0" apply false
     id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.2" apply false
     jacoco

--- a/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -176,7 +176,7 @@ private const val HTTP_TIMEOUT: Long = 300
                         MediaType.parse(mediaType ?: JsonMediaType), Serializer.jacksonObjectMapper.writeValueAsString(content)
                         {{/jackson}}
                         {{#kotlinx_serialization}}
-                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.jvmJson.encodeToString(content)
+                        MediaType.parse(mediaType ?: JsonMediaType), Serializer.kotlinxSerializationJson.encodeToString(content)
                         {{/kotlinx_serialization}}
                     )
                 }
@@ -195,7 +195,7 @@ private const val HTTP_TIMEOUT: Long = 300
                     Serializer.jacksonObjectMapper.writeValueAsString(content)
                     {{/jackson}}
                     {{#kotlinx_serialization}}
-                    Serializer.jvmJson.encodeToString(content)
+                    Serializer.kotlinxSerializationJson.encodeToString(content)
                     {{/kotlinx_serialization}}
                         .toRequestBody((mediaType ?: JsonMediaType).toMediaTypeOrNull())
                 }
@@ -215,7 +215,7 @@ private const val HTTP_TIMEOUT: Long = 300
         if (T::class.java == File::class.java) {
             // return tempFile
             {{^supportAndroidApiLevel25AndBelow}}
-            // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options        
+            // Attention: if you are developing an android app that supports API Level 25 and bellow, please check flag supportAndroidApiLevel25AndBelow in https://openapi-generator.tech/docs/generators/kotlin#config-options
             val tempFile = java.nio.file.Files.createTempFile("tmp.{{packageName}}", null).toFile()
             {{/supportAndroidApiLevel25AndBelow}}
             {{#supportAndroidApiLevel25AndBelow}}
@@ -243,7 +243,7 @@ private const val HTTP_TIMEOUT: Long = 300
                 {{#moshi}}Serializer.moshi.adapter<T>().fromJson(bodyContent){{/moshi}}{{!
                 }}{{#gson}}Serializer.gson.fromJson(bodyContent, (object: TypeToken<T>(){}).getType()){{/gson}}{{!
                 }}{{#jackson}}Serializer.jacksonObjectMapper.readValue(bodyContent, object: TypeReference<T>() {}){{/jackson}}{{!
-                }}{{#kotlinx_serialization}}Serializer.jvmJson.decodeFromString<T>(bodyContent){{/kotlinx_serialization}}
+                }}{{#kotlinx_serialization}}Serializer.kotlinxSerializationJson.decodeFromString<T>(bodyContent){{/kotlinx_serialization}}
             else ->  throw UnsupportedOperationException("responseBody currently only supports JSON body.")
         }
     }
@@ -320,7 +320,7 @@ private const val HTTP_TIMEOUT: Long = 300
         {{/hasAuthMethods}}
 
         val url = httpUrl.newBuilder()
-            .addPathSegments(requestConfig.path.trimStart('/'))
+            .addEncodedPathSegments(requestConfig.path.trimStart('/'))
             .apply {
                 requestConfig.query.forEach { query ->
                     query.value.forEach { queryValue ->
@@ -439,7 +439,7 @@ private const val HTTP_TIMEOUT: Long = 300
         return Serializer.jacksonObjectMapper.writeValueAsString(value).replace("\"", "")
         {{/jackson}}
         {{#kotlinx_serialization}}
-        return Serializer.jvmJson.encodeToString(value).replace("\"", "")
+        return Serializer.kotlinxSerializationJson.encodeToString(value).replace("\"", "")
         {{/kotlinx_serialization}}
         {{/toJson}}
         {{^toJson}}

--- a/dataland-edc-dummyserver/Dockerfile
+++ b/dataland-edc-dummyserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jre-alpine
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 COPY ./build/libs/dataland-edc-dummyserver-*.jar /app/edc-dummyserver.jar
 EXPOSE 8080
 WORKDIR /app

--- a/dataland-edc-server/Dockerfile
+++ b/dataland-edc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jre-alpine
+FROM eclipse-temurin:17.0.4.1_1-jre-alpine
 COPY ./build/libs/dataland-edc-server-*-all.jar /app/edc-server.jar
 COPY ./vault.properties ./keystore.jks ./config.properties /app/
 EXPOSE 8080

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,12 +8,12 @@ dependencyResolutionManagement {
         create("libs") {
             library("springdoc-openapi-ui", "org.springdoc:springdoc-openapi-ui:1.6.11")
 
-            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.9.0")
+            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.9.1")
             library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:5.9.0")
             library("junit-jupiter-api", "org.junit.jupiter:junit-jupiter-api:5.9.0")
 
-            library("moshi-kotlin", "com.squareup.moshi:moshi-kotlin:1.13.0")
-            library("moshi-adapters", "com.squareup.moshi:moshi-adapters:1.13.0")
+            library("moshi-kotlin", "com.squareup.moshi:moshi-kotlin:1.14.0")
+            library("moshi-adapters", "com.squareup.moshi:moshi-adapters:1.14.0")
 
             library("swagger-jaxrs2-jakarta", "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.2")
             library("swagger-gradle-plugin", "io.swagger.core.v3:swagger-gradle-plugin:2.2.2")


### PR DESCRIPTION
# Manual Maintenance Sprint 26
Note: To create a PR using this template add the query parameter `template=manual_maintenance.md` to the merge request creation URL (or simply copy this md file into the description)

# Maintenance tasks (to be completed by the assignee)
## EDC
### Skipped updates
The following known issues need to be reviewed in case a compatible version is available. Add new known issues as they appear.
- [x] ktlint 0.45.2 (higher version is not compatible with jlleitschuh plugin)

### Gradle update
- [x] Execute `gradlew dependencyUpdates` to get a report on Dependencies with updates
- [x] Update `settings.gradle.kts` (for libraries), `build.gradle.kts` (for plugins) and `gradle.properties` (for jacoco and ktlint)
  Note: fasterXML is managed by spring, thus NO manual version update should be conducted
- [x] update the gradle wrapper: execute `gradle wrapper --gradle-version X.Y.Z`

### OpenAPI update
- [x] If you updated the OpenAPI-Generator, also update the `dataland-edc-client/openApiTemplate` folder as described in the README.md

### Dockerfile updates
Update versions in the following dockerfiles
- [x] `./dataland-edc-dummyserver/Dockerfile`
- [x] `./dataland-edc-server/Dockerfile`

## Conclusion
- [x] After updating all components check if everything still works
- [x] This template has been updated to reflect the latest state of tasks required and known issues with upgrades

# Review (to be completed by the reviewer)
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github.
- [x] A peer-review has been executed
  - [x] The code has been manually inspected by someone who did not implement the feature
  - [x] ~The new feature was observed "in running software"~
- [x] The PR actually implements what is described in the JIRA-Issue
- [x] ~At least one E2E Test exists testing the new feature~
- [x] ~Documentation is updated as required~
- [x] ~The automated deployment is updated if required~
- [x] ~There is at least one picture for each story, which was created before coding has started~
- [x] The test-script `dataland-edc-server/test/devtest.sh` still works. Run it locally!
- [x] ~If the Dataland-internal API of the EDC has changed (in spec or behaviour), the dummyEDC has also been adopted to those changes~