### PR TITLE
Dala 659 dependency update sprint 28

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/manual_maintenance.md
@@ -6,6 +6,7 @@ Note: To create a PR using this template add the query parameter `template=manua
 ### Skipped updates
 The following known issues need to be reviewed in case a compatible version is available. Add new known issues as they appear.
 - [ ] ktlint 0.45.2 (higher version is not compatible with jlleitschuh plugin)
+- [ ] sonarqube 3.4.0.2513 not update to 3.5.X, due to issues in file resolving mechanism
 
 ### Gradle update
 - [ ] Execute `gradlew dependencyUpdates` to get a report on Dependencies with updates

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
         if: always()
         run: |
           ./gradlew jacocoTestReport --no-daemon --stacktrace
-          ./gradlew sonar --no-daemon --stacktrace
+          ./gradlew sonarqube --no-daemon --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
         if: always()
         run: |
           ./gradlew jacocoTestReport --no-daemon --stacktrace
-          ./gradlew sonarqube --no-daemon --stacktrace
+          ./gradlew sonar --no-daemon --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
 extra["OpenApiSpec"] = "OpenApiSpec.json"
 
 subprojects {
-    sonarqube {
+    sonar {
         isSkipProject = true
     }
     apply(plugin = "maven-publish")
@@ -81,7 +81,7 @@ tasks.dependencyUpdates.configure {
     gradleReleaseChannel = "current"
 }
 
-sonarqube {
+sonar {
     properties {
         property("sonar.projectKey", "d-fine_datalandEDC")
         property("sonar.organization", "d-fine")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
 extra["OpenApiSpec"] = "OpenApiSpec.json"
 
 subprojects {
-    sonar {
+    sonarqube {
         isSkipProject = true
     }
     apply(plugin = "maven-publish")
@@ -68,7 +68,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     kotlin("jvm") version "1.7.21"
     kotlin("plugin.spring") version "1.7.21" apply false
-    id("org.sonarqube") version "3.5.0.2730"
+    id("org.sonarqube") version "3.4.0.2513"
     id("org.openapi.generator") version "6.2.1" apply false
     id("org.springdoc.openapi-gradle-plugin") version "1.4.0" apply false
     id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.6" apply false
@@ -81,7 +81,7 @@ tasks.dependencyUpdates.configure {
     gradleReleaseChannel = "current"
 }
 
-sonar {
+sonarqube {
     properties {
         property("sonar.projectKey", "d-fine_datalandEDC")
         property("sonar.organization", "d-fine")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
 
 plugins {
     id("org.springframework.boot") version "2.7.4" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.21.0"
+    id("io.gitlab.arturbosch.detekt") version "1.20.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     kotlin("jvm") version "1.7.20"
     kotlin("plugin.spring") version "1.7.20" apply false
@@ -122,8 +122,8 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,8 +122,8 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,7 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
     detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
 
 plugins {
     id("org.springframework.boot") version "2.7.4" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     kotlin("jvm") version "1.7.20"
     kotlin("plugin.spring") version "1.7.20" apply false
@@ -122,8 +122,8 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,15 +63,15 @@ subprojects {
 }
 
 plugins {
-    id("org.springframework.boot") version "2.7.4" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("org.springframework.boot") version "2.7.5" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.22.0-RC3"
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
-    kotlin("jvm") version "1.7.20"
-    kotlin("plugin.spring") version "1.7.20" apply false
-    id("org.sonarqube") version "3.4.0.2513"
-    id("org.openapi.generator") version "6.2.0" apply false
+    kotlin("jvm") version "1.7.21"
+    kotlin("plugin.spring") version "1.7.21" apply false
+    id("org.sonarqube") version "3.5.0.2730"
+    id("org.openapi.generator") version "6.2.1" apply false
     id("org.springdoc.openapi-gradle-plugin") version "1.4.0" apply false
-    id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.4" apply false
+    id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.6" apply false
     jacoco
     id("com.github.ben-manes.versions") version "0.43.0"
     id("com.github.johnrengelman.shadow") version "7.1.2" apply false
@@ -122,8 +122,8 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.22.0-RC3")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.21")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ tasks.jacocoTestReport {
 
 dependencies {
     detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.22.0-RC3")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.21")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,17 +63,17 @@ subprojects {
 }
 
 plugins {
-    id("org.springframework.boot") version "2.7.3" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("org.springframework.boot") version "2.7.4" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
-    kotlin("jvm") version "1.7.10"
-    kotlin("plugin.spring") version "1.7.10" apply false
+    kotlin("jvm") version "1.7.20"
+    kotlin("plugin.spring") version "1.7.20" apply false
     id("org.sonarqube") version "3.4.0.2513"
-    id("org.openapi.generator") version "6.1.0" apply false
+    id("org.openapi.generator") version "6.2.0" apply false
     id("org.springdoc.openapi-gradle-plugin") version "1.4.0" apply false
-    id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.2" apply false
+    id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.4" apply false
     jacoco
-    id("com.github.ben-manes.versions") version "0.42.0"
+    id("com.github.ben-manes.versions") version "0.43.0"
     id("com.github.johnrengelman.shadow") version "7.1.2" apply false
 }
 
@@ -122,8 +122,8 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
 
 plugins {
     id("org.springframework.boot") version "2.7.4" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.21.0"
+    id("io.gitlab.arturbosch.detekt") version "1.20.0"
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     kotlin("jvm") version "1.7.20"
     kotlin("plugin.spring") version "1.7.20" apply false
@@ -122,7 +122,7 @@ tasks.jacocoTestReport {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
     detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ tasks.jacocoTestReport {
 
 dependencies {
     detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.20.0")
-    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.10")
+    detekt("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.20")
 }
 
 detekt {

--- a/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -123,6 +123,12 @@ private const val HTTP_TIMEOUT: Long = 300
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String?): RequestBody =
         when {
+            {{#jvm-okhttp3}}
+            content is File -> RequestBody.create(MediaType.parse(mediaType ?: guessContentTypeFromFile(content)), content)
+            {{/jvm-okhttp3}}
+            {{#jvm-okhttp4}}
+            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
+            {{/jvm-okhttp4}}
             mediaType == FormDataMediaType ->
                 MultipartBody.Builder()
                     .setType(MultipartBody.FORM)
@@ -130,27 +136,41 @@ private const val HTTP_TIMEOUT: Long = 300
                         // content's type *must* be Map<String, PartConfig<*>>
                         @Suppress("UNCHECKED_CAST")
                         (content as Map<String, PartConfig<*>>).forEach { (name, part) ->
-                            val contentType = part.headers.remove("Content-Type")
-                            val bodies = if (part.body is Iterable<*>) part.body else listOf(part.body)
-                            bodies.forEach { body ->
-                                val headers = part.headers.toMutableMap() +
-                                    ("Content-Disposition" to "form-data; name=\"$name\"" + if (body is File) "; filename=\"${body.name}\"" else "")
-                                addPart({{#jvm-okhttp3}}Headers.of(headers){{/jvm-okhttp3}}{{#jvm-okhttp4}}headers.toHeaders(){{/jvm-okhttp4}},
-                                    requestSingleBody(body, contentType))
+                            if (part.body is File) {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"; filename=\"${part.body.name}\"")
+                                {{#jvm-okhttp3}}
+                                val fileMediaType = MediaType.parse(guessContentTypeFromFile(part.body))
+                                addPart(
+                                    Headers.of(partHeaders),
+                                    RequestBody.create(fileMediaType, part.body)
+                                )
+                                {{/jvm-okhttp3}}
+                                {{#jvm-okhttp4}}
+                                val fileMediaType = guessContentTypeFromFile(part.body).toMediaTypeOrNull()
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    part.body.asRequestBody(fileMediaType)
+                                )
+                                {{/jvm-okhttp4}}
+                            } else {
+                                val partHeaders = part.headers.toMutableMap() +
+                                    ("Content-Disposition" to "form-data; name=\"$name\"")
+                                {{#jvm-okhttp3}}
+                                addPart(
+                                    Headers.of(partHeaders),
+                                    RequestBody.create(null, parameterToString(part.body))
+                                )
+                                {{/jvm-okhttp3}}
+                                {{#jvm-okhttp4}}
+                                addPart(
+                                    partHeaders.toHeaders(),
+                                    parameterToString(part.body).toRequestBody(null)
+                                )
+                                {{/jvm-okhttp4}}
                             }
                         }
                     }.build()
-            else -> requestSingleBody(content, mediaType)
-        }
-
-    protected inline fun <reified T> requestSingleBody(content: T, mediaType: String?): RequestBody =
-        when {
-            {{#jvm-okhttp3}}
-            content is File -> RequestBody.create(MediaType.parse(mediaType ?: guessContentTypeFromFile(content)), content)
-            {{/jvm-okhttp3}}
-            {{#jvm-okhttp4}}
-            content is File -> content.asRequestBody((mediaType ?: guessContentTypeFromFile(content)).toMediaTypeOrNull())
-            {{/jvm-okhttp4}}
             mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
                     // content's type *must* be Map<String, PartConfig<*>>

--- a/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/dataland-edc-client/openApiTemplate/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -350,7 +350,7 @@ private const val HTTP_TIMEOUT: Long = 300
             }.build()
 
         // take content-type/accept from spec or set to default (application/json) if not defined
-        if (requestConfig.headers[ContentType].isNullOrEmpty()) {
+        if (requestConfig.body != null && requestConfig.headers[ContentType].isNullOrEmpty()) {
             requestConfig.headers[ContentType] = JsonMediaType
         }
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
@@ -358,16 +358,16 @@ private const val HTTP_TIMEOUT: Long = 300
         }
         val headers = requestConfig.headers
 
-        if(headers[ContentType].isNullOrEmpty()) {
-            throw kotlin.IllegalStateException("Missing Content-Type header. This is required.")
-        }
-
-        if(headers[Accept].isNullOrEmpty()) {
+        if (headers[Accept].isNullOrEmpty()) {
             throw kotlin.IllegalStateException("Missing Accept header. This is required.")
         }
 
-        // TODO: support multiple contentType options here.
-        val contentType = (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        val contentType = if (headers[ContentType] != null) {
+            // TODO: support multiple contentType options here.
+            (headers[ContentType] as String).substringBefore(";").lowercase(Locale.getDefault())
+        } else {
+            null
+        }
 
         val request = when (requestConfig.method) {
             RequestMethod.DELETE -> Request.Builder().url(url).delete(requestBody(requestConfig.body, contentType))

--- a/dataland-edc-dummyserver/Dockerfile
+++ b/dataland-edc-dummyserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4.1_1-jre-alpine
+FROM eclipse-temurin:17.0.5_8-jre-alpine
 COPY ./build/libs/dataland-edc-dummyserver-*.jar /app/edc-dummyserver.jar
 EXPOSE 8080
 WORKDIR /app

--- a/dataland-edc-server/Dockerfile
+++ b/dataland-edc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4.1_1-jre-alpine
+FROM eclipse-temurin:17.0.5_8-jre-alpine
 COPY ./build/libs/dataland-edc-server-*-all.jar /app/edc-server.jar
 COPY ./vault.properties ./keystore.jks ./config.properties /app/
 EXPOSE 8080

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ include("dataland-edc-server")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            library("springdoc-openapi-ui", "org.springdoc:springdoc-openapi-ui:1.6.11")
+            library("springdoc-openapi-ui", "org.springdoc:springdoc-openapi-ui:1.6.12")
 
             library("junit-jupiter", "org.junit.jupiter:junit-jupiter:5.9.1")
             library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:5.9.0")
@@ -15,9 +15,9 @@ dependencyResolutionManagement {
             library("moshi-kotlin", "com.squareup.moshi:moshi-kotlin:1.14.0")
             library("moshi-adapters", "com.squareup.moshi:moshi-adapters:1.14.0")
 
-            library("swagger-jaxrs2-jakarta", "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.2")
-            library("swagger-gradle-plugin", "io.swagger.core.v3:swagger-gradle-plugin:2.2.2")
-            library("swagger-annotations", "io.swagger.core.v3:swagger-annotations:2.2.2")
+            library("swagger-jaxrs2-jakarta", "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.4")
+            library("swagger-gradle-plugin", "io.swagger.core.v3:swagger-gradle-plugin:2.2.4")
+            library("swagger-annotations", "io.swagger.core.v3:swagger-annotations:2.2.4")
 
             library("okhttp", "com.squareup.okhttp3:okhttp:4.10.0")
             library("rs-api", "jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,9 @@ dependencyResolutionManagement {
             library("moshi-kotlin", "com.squareup.moshi:moshi-kotlin:1.14.0")
             library("moshi-adapters", "com.squareup.moshi:moshi-adapters:1.14.0")
 
-            library("swagger-jaxrs2-jakarta", "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.4")
-            library("swagger-gradle-plugin", "io.swagger.core.v3:swagger-gradle-plugin:2.2.4")
-            library("swagger-annotations", "io.swagger.core.v3:swagger-annotations:2.2.4")
+            library("swagger-jaxrs2-jakarta", "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.6")
+            library("swagger-gradle-plugin", "io.swagger.core.v3:swagger-gradle-plugin:2.2.6")
+            library("swagger-annotations", "io.swagger.core.v3:swagger-annotations:2.2.6")
 
             library("okhttp", "com.squareup.okhttp3:okhttp:4.10.0")
             library("rs-api", "jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")


### PR DESCRIPTION
# Manual Maintenance Sprint 30

# Maintenance tasks (to be completed by the assignee)
## EDC
### Skipped updates
The following known issues need to be reviewed in case a compatible version is available. Add new known issues as they appear.
- [x] ktlint 0.45.2 (higher version is not compatible with jlleitschuh plugin)

### Gradle update
- [x] Execute `gradlew dependencyUpdates` to get a report on Dependencies with updates
- [x] Update `settings.gradle.kts` (for libraries), `build.gradle.kts` (for plugins) and `gradle.properties` (for jacoco and ktlint)
  Note: fasterXML is managed by spring, thus NO manual version update should be conducted
- [x] update the gradle wrapper: execute `gradle wrapper --gradle-version X.Y.Z`

### OpenAPI update
- [x] If you updated the OpenAPI-Generator, also update the `dataland-edc-client/openApiTemplate` folder as described in the README.md

### Dockerfile updates
Update versions in the following dockerfiles
- [x] `./dataland-edc-dummyserver/Dockerfile`
- [x] `./dataland-edc-server/Dockerfile`

## Conclusion
- [x] After updating all components check if everything still works
- [x] This template has been updated to reflect the latest state of tasks required and known issues with upgrades

# Review (to be completed by the reviewer)
- [x] The Github Actions (including Sonarqube Gateway and Lint Checks) are green. This is enforced by Github.
- [x] A peer-review has been executed
    - [x] The code has been manually inspected by someone who did not implement the feature
    - [x] It was observed "in running software" that everything still works fine
- [x] The PR actually implements what is described above
- [x] Documentation is updated as required
- [x] The automated deployment is updated if required
- [x] The test-script `dataland-edc-server/test/devtest.sh` still works. Run it locally!
- [x] If the behaviour of the EDC has changed from an external perspective, the dummyEDC has also been adopted to those changes
